### PR TITLE
Update Facebook SDK to version 18.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ repositories {
     google()
 }
 
-def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '16.+')
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '18.+')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, './', 'package.json')))
 
-FBSDKVersion = "16.3.1"
+FBSDKVersion = "18.1.3"
 
 Pod::Spec.new do |s|
   s.name          = package['name']


### PR DESCRIPTION
Upgraded Facebook SDK version from 16.x to 18.x in both Gradle and podspec files to ensure compatibility with the latest features and fixes. This change addresses potential deprecations and improves stability.

Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

Test Plan:

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!
